### PR TITLE
enhance elastic alert

### DIFF
--- a/pkg/boot/alert.go
+++ b/pkg/boot/alert.go
@@ -39,6 +39,10 @@ type AlertSampleMessage struct {
 	ES           model.EsConfig `json:"es"`
 	Index        string         `json:"index"`
 	Ids          []string       `json:"ids"`
+	Node         string         `json:"node"`
+	Workload     string         `json:"workload"`
+	Pod          string         `json:"pod"`
+	Namespace    string         `json:"namespace"`
 	QueryString  string         `json:"query_string"`
 	BooleanQuery string         `json:"boolean_query"`
 }

--- a/pkg/boot/prometheus.go
+++ b/pkg/boot/prometheus.go
@@ -62,6 +62,10 @@ type ElasticAlertMetrics struct {
 	Index string
 	Key   string
 	//Ids   string
+	Node         string
+	Workload     string
+	Pod          string
+	Namespace    string
 	QueryString  string
 	BooleanQuery string
 	Value        int64
@@ -126,12 +130,7 @@ func (rc *RuleStatusCollector) collectElasticAlertMetrics(ch chan<- prometheus.M
 		m := val.(*ElasticAlertPrometheusMetrics)
 		m.ElasticAlert.Range(func(key, value any) bool {
 			v := value.(ElasticAlertMetrics)
-			var labelValues []string
-			if rc.Ea.opts.IsDebug() {
-				labelValues = []string{v.UniqueId, v.Index, v.QueryString, v.BooleanQuery}
-			} else {
-				labelValues = []string{v.UniqueId, v.Index}
-			}
+			labelValues := []string{v.UniqueId, v.Index, v.Node, v.Workload, v.Pod, v.Namespace}
 			ch <- prometheus.MustNewConstMetric(rc.ElasticMetricsDesc, prometheus.GaugeValue, float64(v.Value), labelValues...)
 			return true
 		})
@@ -236,12 +235,7 @@ func NewRuleStatusCollector(ea *ElasticAlert) *RuleStatusCollector {
 		ElasticMetricsDesc: prometheus.NewDesc(
 			ea.buildFQName("hits"),
 			"Show hits/matched number for each rule query",
-			func() []string {
-				if ea.opts.IsDebug() {
-					return []string{"unique_id", "index", "query_string", "boolean_query"}
-				}
-				return []string{"unique_id", "index"}
-			}(),
+			[]string{"unique_id", "index", "node", "workload", "pod", "namespace"},
 			prometheus.Labels{},
 		),
 	}

--- a/pkg/boot/run_test.go
+++ b/pkg/boot/run_test.go
@@ -1,0 +1,62 @@
+package boot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openinsight-proj/elastic-alert/pkg/conf"
+	"github.com/openinsight-proj/elastic-alert/pkg/model"
+	"github.com/openinsight-proj/elastic-alert/pkg/utils/xtime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBufferTime(t *testing.T) {
+	t.Run("test default timeframe", func(t *testing.T) {
+		d := getBufferTime(&model.Rule{}, &conf.AppConfig{})
+		assert.Equal(t, time.Minute, d)
+	})
+	t.Run("test empty model.rule timeframe", func(t *testing.T) {
+		d := getBufferTime(&model.Rule{}, &conf.AppConfig{
+			BufferTime: xtime.TimeLimit{
+				Seconds: 0,
+				Minutes: 5,
+				Days:    0,
+			},
+		})
+		assert.Equal(t, time.Minute*5, d)
+	})
+	t.Run("test empty AppConfig.BufferTime", func(t *testing.T) {
+		d := getBufferTime(&model.Rule{
+			Query: model.Query{
+				Config: model.QueryConfig{
+					Timeframe: xtime.TimeLimit{
+						Seconds: 5,
+					},
+				},
+			},
+			RawContent: "",
+			FilePath:   "",
+		}, &conf.AppConfig{})
+		assert.Equal(t, time.Second*5, d)
+	})
+	t.Run("test model.Rule is priority of AppConfig.BufferTime", func(t *testing.T) {
+		d := getBufferTime(&model.Rule{
+			Query: model.Query{
+				Config: model.QueryConfig{
+					Timeframe: xtime.TimeLimit{
+						Seconds: 5,
+					},
+				},
+			},
+			RawContent: "",
+			FilePath:   "",
+		}, &conf.AppConfig{
+			BufferTime: xtime.TimeLimit{
+				Seconds: 0,
+				Minutes: 5,
+				Days:    0,
+			},
+		})
+		assert.Equal(t, time.Second*5, d)
+	})
+}

--- a/pkg/server/services/rule.go
+++ b/pkg/server/services/rule.go
@@ -253,9 +253,9 @@ func (rs *RuleService) batchUpsertData(rules map[string]*model.Rule) error {
 }
 
 func (rs *RuleService) generateDataKey(policy, uniqueId string) string {
-	return strings.Join([]string{policy, uniqueId}, "-") + ".rule.yaml"
+	return strings.Join([]string{policy, uniqueId}, ".") + ".rule.yaml"
 }
 
 func (rs *RuleService) splitPolicy(policyUniqueId string) string {
-	return strings.Split(policyUniqueId, "-")[0]
+	return strings.Split(policyUniqueId, ".")[0]
 }


### PR DESCRIPTION
This PR's work:
- add `node`,`workload`,`pod`,`namespace` to `elastic_alert_hits` metrics and them can be set by labels in query of query of Rule:
```
enabled: true
es:
  addresses:
    - https://ip:30626
  conn_timeout: 300
  password: Cn21UX1RxU01Y0Lj08EAM84W
  username: elastic
  version: v7
index: insight-es-k8s-logs-alias
query:
  annotations: {}
  boolean_query: '{"bool":{"filter":[{"term":{"tag.keyword":{"value":"kube.containers"}}},{"terms":{"kubernetes.namespace_name.keyword":["insight-system"]}},{"terms":{"cluster_uuid.keyword":["a2c40560-7b3e-4913-9df2-11ddd86567f8"]}},{"terms":{"kubernetes.pod_name.keyword":["insight-server-84995c84b7-tx4ll"]}},{"query_string":{"query":"log:(error
    OR debug)"}}]}}'
  config:
    num_events: 1
    timeframe:
      days: 0
      minutes: 0
      seconds: 600
  labels:
    alertname: log-rule
    node: ""
    workload: ""
    pod: "insight-pod1"
    namespace: ""
  query_string: ""
  type: frequency
run_every:
  days: 0
  minutes: 0
  seconds: 10
unique_id: log-alert-test-2.log-rule
```
- change rule key generator's separator from `-` to `.`
- change job running logic: every job will run the DSL with the entire rule timeframe or app conf timeframe.
- no longer add `query_string` and `boolean_query` labels in `elastic_alert_hits` metric, you can get the job running detail in its console log with `--debug` enabled.