### PR TITLE
add cluster label to hit metrics

### DIFF
--- a/pkg/boot/alert.go
+++ b/pkg/boot/alert.go
@@ -43,6 +43,7 @@ type AlertSampleMessage struct {
 	Workload     string         `json:"workload"`
 	Pod          string         `json:"pod"`
 	Namespace    string         `json:"namespace"`
+	Cluster      string         `json:"cluster"`
 	QueryString  string         `json:"query_string"`
 	BooleanQuery string         `json:"boolean_query"`
 }

--- a/pkg/boot/prometheus.go
+++ b/pkg/boot/prometheus.go
@@ -66,6 +66,7 @@ type ElasticAlertMetrics struct {
 	Workload     string
 	Pod          string
 	Namespace    string
+	Cluster      string
 	QueryString  string
 	BooleanQuery string
 	Value        int64
@@ -130,7 +131,7 @@ func (rc *RuleStatusCollector) collectElasticAlertMetrics(ch chan<- prometheus.M
 		m := val.(*ElasticAlertPrometheusMetrics)
 		m.ElasticAlert.Range(func(key, value any) bool {
 			v := value.(ElasticAlertMetrics)
-			labelValues := []string{v.UniqueId, v.Index, v.Node, v.Workload, v.Pod, v.Namespace}
+			labelValues := []string{v.UniqueId, v.Index, v.Node, v.Workload, v.Pod, v.Namespace, v.Cluster}
 			ch <- prometheus.MustNewConstMetric(rc.ElasticMetricsDesc, prometheus.GaugeValue, float64(v.Value), labelValues...)
 			return true
 		})
@@ -235,7 +236,7 @@ func NewRuleStatusCollector(ea *ElasticAlert) *RuleStatusCollector {
 		ElasticMetricsDesc: prometheus.NewDesc(
 			ea.buildFQName("hits"),
 			"Show hits/matched number for each rule query",
-			[]string{"unique_id", "index", "node", "workload", "pod", "namespace"},
+			[]string{"unique_id", "index", "node", "workload", "pod", "namespace", "cluster"},
 			prometheus.Labels{},
 		),
 	}

--- a/pkg/boot/run.go
+++ b/pkg/boot/run.go
@@ -377,6 +377,7 @@ func (ea *ElasticAlert) addAlertHitsMetrics(uniqueId string, path string, key st
 				Workload:     sampleMsg.Workload,
 				Pod:          sampleMsg.Pod,
 				Namespace:    sampleMsg.Namespace,
+				Cluster:      sampleMsg.Cluster,
 				Value:        int64(len(sampleMsg.Ids)),
 				QueryString:  sampleMsg.QueryString,
 				BooleanQuery: sampleMsg.BooleanQuery,
@@ -398,6 +399,7 @@ func (ea *ElasticAlert) pushAlert() {
 			Workload:     alert.Rule.Query.Labels["workload"],
 			Pod:          alert.Rule.Query.Labels["pod"],
 			Namespace:    alert.Rule.Query.Labels["namespace"],
+			Cluster:      alert.Rule.Query.Labels["cluster"],
 			QueryString:  alert.Rule.Query.QueryString,
 			BooleanQuery: string(alert.Rule.Query.BooleanQuery),
 		}


### PR DESCRIPTION
result like:
```
# HELP elastic_alert_hits Show hits/matched number for each rule query
# TYPE elastic_alert_hits gauge
elastic_alert_hits{cluster="a2c40560",index="insight-es-k8s-logs*",namespace="insight-system",node="",pod="",unique_id="log-insigt-system-info.info-rule",workload=""} 25
```