### PR TITLE
Feature: support `ea` running in leader election mode.

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,3 +1,7 @@
+server:
+  enabled: true
+  leader_election:
+    enabled: false
 exporter:
   enabled: true
   listen_addr: ":9003"

--- a/helm-chart/elastic-alert/Chart.yaml
+++ b/helm-chart/elastic-alert/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.5
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.1.5"
+appVersion: "v1.2.0"

--- a/helm-chart/elastic-alert/templates/clusterrole.yaml
+++ b/helm-chart/elastic-alert/templates/clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if or .Values.leader_election.enabled .Values.clusterRole.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "elastic-alert.labels" . | nindent 4 }}
+  name: {{ include "elastic-alert.fullname" . }}
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+{{- end }}

--- a/helm-chart/elastic-alert/templates/clusterrolebinding.yaml
+++ b/helm-chart/elastic-alert/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if or .Values.leader_election.enabled .Values.clusterRole.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "elastic-alert.labels" . | nindent 4 }}
+  name: {{ include "elastic-alert.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "elastic-alert.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "elastic-alert.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm-chart/elastic-alert/templates/setup-configmap.yaml
+++ b/helm-chart/elastic-alert/templates/setup-configmap.yaml
@@ -9,6 +9,8 @@ data:
   config.yaml: |-
     server:
       enabled: true
+      leader_election:
+        enabled: {{ .Values.leader_election.enabled | default false }}
       listen_addr: ":8080"
       datasource:
         type: configmap

--- a/helm-chart/elastic-alert/values.yaml
+++ b/helm-chart/elastic-alert/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 1
 
+leader_election:
+  enabled: false
+
 image:
   registry: ghcr.io
   repository: openinsight-proj/elastic-alert
@@ -118,3 +121,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+clusterRole:
+  create: false

--- a/helm-chart/elastic-alert/values.yaml
+++ b/helm-chart/elastic-alert/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: openinsight-proj/elastic-alert
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.1.5"
+  tag: "v1.2.0"
 
 configReloader:
   image:

--- a/pkg/conf/app.go
+++ b/pkg/conf/app.go
@@ -15,6 +15,11 @@ import (
 
 var AppConf *AppConfig
 
+type LeaderElection struct {
+	Enabled   bool   `yaml:"enabled" default:"true"`
+	Namespace string `yaml:"namespace" default:"default"`
+}
+
 type Datasource struct {
 	Type   string         `yaml:"type" default:"configmap"`
 	Config map[string]any `yaml:"config"`
@@ -23,9 +28,10 @@ type Datasource struct {
 // AppConfig is application global configure
 type AppConfig struct {
 	Server struct {
-		ListenAddr string     `yaml:"listen_addr" default:":8080"`
-		Enabled    bool       `yaml:"enabled" default:"true"`
-		DB         Datasource `yaml:"datasource"`
+		ListenAddr     string         `yaml:"listen_addr" default:":8080"`
+		Enabled        bool           `yaml:"enabled" default:"true"`
+		DB             Datasource     `yaml:"datasource"`
+		LeaderElection LeaderElection `yaml:"leader_election"`
 	} `yaml:"server"`
 
 	Exporter struct {


### PR DESCRIPTION
close https://github.com/openinsight-proj/elastic-alert/issues/38

This unit test is complex, so run it directly in the environment to see what happens:

1. deloy with `2` replicas:
<img width="1428" alt="企业微信截图_046b7156-341c-4fa5-a601-18d5370a7656" src="https://github.com/openinsight-proj/elastic-alert/assets/12468337/270730f8-7aaf-449b-8c35-107b0cba6ce6">

<img width="475" alt="企业微信截图_203709d7-9e64-4d5a-ab50-7ff6dbc75eb2" src="https://github.com/openinsight-proj/elastic-alert/assets/12468337/72921f76-ccd1-443b-bafa-a17a8c876cbd">

2.  kill one pod manually, the new instances and immediately become leaders：
<img width="1438" alt="企业微信截图_08f3489b-d080-4e6d-97ba-993f01124cd9" src="https://github.com/openinsight-proj/elastic-alert/assets/12468337/304b0963-68a8-4acf-aac0-fde5ed70c64f">

3. sacle down deploy replicas to `1` and sacle up `2`: The stadby pod becomes the new leader and able to servering normally:
<img width="1433" alt="企业微信截图_58446f23-b611-446d-af47-016bf6c4d749" src="https://github.com/openinsight-proj/elastic-alert/assets/12468337/fc70b817-8931-40c5-b4fd-7978a6e199d0">
<img width="374" alt="企业微信截图_ca974599-d024-4518-bf25-63ab6384156c" src="https://github.com/openinsight-proj/elastic-alert/assets/12468337/7b9cc6b2-1102-4984-8ff0-3995bc7208b4">
